### PR TITLE
feat: add Cloudflare-compatible Content Security Policy

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,4 +1,5 @@
 /*
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://*.cloudflare.com https://*.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self' https://*.cloudflare.com; object-src 'none'; base-uri 'self'; form-action 'self'
   Referrer-Policy: strict-origin-when-cross-origin
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY


### PR DESCRIPTION
Add CSP header with Cloudflare-specific allowances for:
- Cloudflare injected scripts and analytics
- Google Fonts integration
- Inline styles for compatibility