### PR TITLE
feat: remove unsafe-inline from script-src, use hash for JSON-LD

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,5 +1,5 @@
 /*
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://*.cloudflare.com https://*.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self' https://*.cloudflare.com; object-src 'none'; base-uri 'self'; form-action 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'sha256-igUgymH4LU1sZaC7MopgYqsS8OCZvHYYkjaNcSgkLic=' https://*.cloudflare.com https://*.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self' https://*.cloudflare.com; object-src 'none'; base-uri 'self'; form-action 'self'
   Referrer-Policy: strict-origin-when-cross-origin
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY


### PR DESCRIPTION
Replace 'unsafe-inline' with specific SHA256 hash for JSON-LD structured data script. This strengthens CSP by only allowing the specific inline script we need.