### PR TITLE
feat: remove unsafe-inline from style-src for maximum CSP security

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,5 +1,5 @@
 /*
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'sha256-igUgymH4LU1sZaC7MopgYqsS8OCZvHYYkjaNcSgkLic=' https://*.cloudflare.com https://*.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self' https://*.cloudflare.com; object-src 'none'; base-uri 'self'; form-action 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'sha256-igUgymH4LU1sZaC7MopgYqsS8OCZvHYYkjaNcSgkLic=' https://*.cloudflare.com https://*.cloudflareinsights.com; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self' https://*.cloudflare.com; object-src 'none'; base-uri 'self'; form-action 'self'
   Referrer-Policy: strict-origin-when-cross-origin
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY


### PR DESCRIPTION
Remove 'unsafe-inline' from style-src directive. Site uses only external CSS from main.css and Google Fonts, no inline styles present.