### PR TITLE
feat: add tools directory with PDF prompt injection detector

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -47,7 +47,6 @@ blockquote, q {
 :root {
   --primary-color: #009999;
   --link-hover: #006666;
-  --social-link-color: #0056b3;
   --text-color: #000;
   --background-color: #fff;
   --spacing-base: 20px;
@@ -106,11 +105,6 @@ li {
   margin-right: var(--spacing-base);
 }
 
-a[href="https://github.com/neilrooney"], 
-a[href="https://www.linkedin.com/in/neil-rooney/"], 
-a[href="https://bsky.app/profile/neilrooney.com"] {
-    color: var(--social-link-color);
-}
 
 
 @media only screen and (max-width: 480px) {

--- a/index.html
+++ b/index.html
@@ -55,9 +55,9 @@
       </p>
       <nav>
         <ul>
+          <li><a href="https://bsky.app/profile/neilrooney.com">Bluesky</a></li>
           <li><a href="https://github.com/neilrooney">GitHub</a></li>
           <li><a href="https://www.linkedin.com/in/neil-rooney/">LinkedIn</a></li>
-          <li><a href="https://bsky.app/profile/neilrooney.com">Bluesky</a></li>
           <li><a href="/tools/">Tools</a></li>
         </ul>
       </nav>

--- a/index.html
+++ b/index.html
@@ -58,6 +58,7 @@
           <li><a href="https://github.com/neilrooney">GitHub</a></li>
           <li><a href="https://www.linkedin.com/in/neil-rooney/">LinkedIn</a></li>
           <li><a href="https://bsky.app/profile/neilrooney.com">Bluesky</a></li>
+          <li><a href="/tools/">Tools</a></li>
         </ul>
       </nav>
     </section>

--- a/robots.txt
+++ b/robots.txt
@@ -5,5 +5,6 @@ User-agent: Googlebot
 Allow: /
 Disallow: /css/
 Disallow: /images/
+Disallow: /tools/
 
 Sitemap: https://neilrooney.com/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -4,12 +4,4 @@
     <loc>https://neilrooney.com/</loc>
     <lastmod>2025-12-14</lastmod>
   </url>
-  <url>
-    <loc>https://neilrooney.com/tools/</loc>
-    <lastmod>2025-12-14</lastmod>
-  </url>
-  <url>
-    <loc>https://neilrooney.com/tools/pdf-prompt-detector/</loc>
-    <lastmod>2025-12-14</lastmod>
-  </url>
 </urlset>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,6 +2,14 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://neilrooney.com/</loc>
-    <lastmod>2025-08-10</lastmod>
+    <lastmod>2025-12-14</lastmod>
+  </url>
+  <url>
+    <loc>https://neilrooney.com/tools/</loc>
+    <lastmod>2025-12-14</lastmod>
+  </url>
+  <url>
+    <loc>https://neilrooney.com/tools/pdf-prompt-detector/</loc>
+    <lastmod>2025-12-14</lastmod>
   </url>
 </urlset>

--- a/tools/css/tools.css
+++ b/tools/css/tools.css
@@ -47,7 +47,6 @@ blockquote, q {
 :root {
   --primary-color: #009999;
   --link-hover: #006666;
-  --social-link-color: #0056b3;
   --text-color: #000;
   --background-color: #fff;
   --spacing-base: 20px;

--- a/tools/css/tools.css
+++ b/tools/css/tools.css
@@ -1,0 +1,223 @@
+
+html, body, h1, h2, p, a, img, ul, li, main, section, nav, div, button, input, label {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    outline: 0;
+    font-weight: inherit;
+    font-style: normal;
+    font-size: 100%;
+    vertical-align: baseline;
+}
+
+:focus {
+    outline: 0;
+}
+
+body {
+    line-height: 1;
+    color: black;
+    background: white;
+}
+
+ul {
+    list-style: none;
+}
+
+table {
+    border-collapse: collapse;
+    border-spacing: 0;
+}
+
+caption, th, td {
+    text-align: left;
+    font-weight: normal;
+}
+
+blockquote:before, blockquote:after,
+q:before, q:after {
+    content: "";
+}
+
+blockquote, q {
+    quotes: "" "";
+}
+
+
+:root {
+  --primary-color: #009999;
+  --link-hover: #006666;
+  --social-link-color: #0056b3;
+  --text-color: #000;
+  --background-color: #fff;
+  --spacing-base: 20px;
+  --spacing-double: 40px;
+  --spacing-triple: 60px;
+  --font-family: "Open Sans", sans-serif;
+  --font-size-base: 1em;
+  --font-size-large: 2em;
+  --line-height: 2em;
+  --warning-color: #d9534f;
+  --success-color: #5cb85c;
+  --border-color: #ddd;
+}
+
+
+body {
+  font-family: var(--font-family);
+  font-weight: 300;
+  line-height: var(--line-height);
+  color: var(--text-color);
+  background: var(--background-color);
+}
+
+a {
+  color: var(--primary-color);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+  color: var(--link-hover);
+}
+
+h1 {
+  font-size: var(--font-size-large);
+}
+
+h2 {
+  font-size: 1.4em;
+  margin-bottom: var(--spacing-base);
+}
+
+.container {
+  max-width: 800px;
+  margin: var(--spacing-triple) auto;
+  padding: 0 var(--spacing-base);
+}
+
+.back-link {
+  display: inline-block;
+  margin-bottom: var(--spacing-double);
+}
+
+p {
+  margin-top: var(--spacing-base);
+}
+
+.tool-list {
+  margin-top: var(--spacing-double);
+}
+
+.tool-list li {
+  margin-bottom: var(--spacing-base);
+}
+
+.tool-description {
+  color: #666;
+  font-size: 0.9em;
+}
+
+/* Upload area */
+.upload-area {
+  border: 2px dashed var(--border-color);
+  padding: var(--spacing-double);
+  text-align: center;
+  margin: var(--spacing-double) 0;
+  cursor: pointer;
+  transition: border-color 0.2s, background-color 0.2s;
+}
+
+.upload-area:hover,
+.upload-area.dragover {
+  border-color: var(--primary-color);
+  background-color: #f9f9f9;
+}
+
+.upload-area input[type="file"] {
+  display: none;
+}
+
+.upload-area p {
+  margin: 0;
+}
+
+.upload-area .hint {
+  color: #666;
+  font-size: 0.9em;
+  margin-top: var(--spacing-base);
+}
+
+/* Results */
+.results {
+  margin-top: var(--spacing-double);
+  display: none;
+}
+
+.results.visible {
+  display: block;
+}
+
+.status {
+  padding: var(--spacing-base);
+  margin-bottom: var(--spacing-base);
+}
+
+.status.clean {
+  background-color: #dff0d8;
+  border: 1px solid var(--success-color);
+  color: #3c763d;
+}
+
+.status.warning {
+  background-color: #f2dede;
+  border: 1px solid var(--warning-color);
+  color: #a94442;
+}
+
+.detection-list {
+  margin-top: var(--spacing-base);
+}
+
+.detection-item {
+  background-color: #fff3cd;
+  border: 1px solid #ffc107;
+  padding: var(--spacing-base);
+  margin-bottom: var(--spacing-base);
+}
+
+.detection-item .page {
+  font-weight: 600;
+  color: #856404;
+}
+
+.detection-item .text {
+  font-family: monospace;
+  background-color: #fff;
+  padding: 10px;
+  margin-top: 10px;
+  word-break: break-word;
+  white-space: pre-wrap;
+}
+
+/* Loading state */
+.loading {
+  text-align: center;
+  padding: var(--spacing-double);
+  display: none;
+}
+
+.loading.visible {
+  display: block;
+}
+
+/* Responsive */
+@media only screen and (max-width: 480px) {
+  .container {
+    margin: var(--spacing-base) auto;
+  }
+
+  .upload-area {
+    padding: var(--spacing-base);
+  }
+}

--- a/tools/index.html
+++ b/tools/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tools | Neil Rooney</title>
+    <meta name="description" content="A collection of simple, useful web tools.">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="css/tools.css">
+</head>
+<body>
+    <main class="container">
+        <a href="/" class="back-link">&larr; Back to neilrooney.com</a>
+
+        <h1>Tools</h1>
+
+        <p>A collection of simple, useful web tools, all vibe coded.</p>
+
+        <ul class="tool-list">
+            <li>
+                <a href="pdf-prompt-detector/">PDF Prompt Injection Detector</a>
+                <p class="tool-description">Upload a PDF to check for potential prompt injection attempts. Useful for screening studies and documents before processing with AI.</p>
+            </li>
+        </ul>
+    </main>
+</body>
+</html>

--- a/tools/pdf-prompt-detector/index.html
+++ b/tools/pdf-prompt-detector/index.html
@@ -1,0 +1,173 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PDF Prompt Injection Detector | Tools | Neil Rooney</title>
+    <meta name="description" content="Upload a PDF to detect potential prompt injection attempts. Screen documents before processing with AI.">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../css/tools.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.0.379/pdf.min.mjs" type="module"></script>
+</head>
+<body>
+    <main class="container">
+        <a href="../" class="back-link">&larr; Back to Tools</a>
+
+        <h1>PDF Prompt Injection Detector</h1>
+
+        <p>Upload a PDF to scan for potential prompt injection attempts. All processing happens in your browser &mdash; no files are uploaded to any server.</p>
+
+        <div class="upload-area" id="uploadArea">
+            <p>Drop a PDF here or click to select</p>
+            <p class="hint">Supports PDF files only</p>
+            <input type="file" id="fileInput" accept=".pdf,application/pdf">
+        </div>
+
+        <div class="loading" id="loading">
+            <p>Scanning PDF...</p>
+        </div>
+
+        <div class="results" id="results">
+            <div class="status" id="status"></div>
+            <div class="detection-list" id="detectionList"></div>
+        </div>
+    </main>
+
+    <script type="module">
+        const pdfjsLib = await import('https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.0.379/pdf.min.mjs');
+        pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.0.379/pdf.worker.min.mjs';
+
+        const injectionPatterns = [
+            { pattern: /ignore\s+(all\s+)?(previous|prior|above)\s+(instructions?|prompts?|context)/gi, name: 'Ignore instructions' },
+            { pattern: /disregard\s+(all\s+)?(previous|prior|above)/gi, name: 'Disregard previous' },
+            { pattern: /forget\s+(everything|all)\s+(above|before|previous)/gi, name: 'Forget previous' },
+            { pattern: /you\s+are\s+now\s+(a|an)\s+/gi, name: 'Role override' },
+            { pattern: /act\s+as\s+(if\s+)?(you\s+are\s+)?(a|an)\s+/gi, name: 'Role injection' },
+            { pattern: /pretend\s+(you\s+are|to\s+be)\s+/gi, name: 'Pretend role' },
+            { pattern: /new\s+instructions?:/gi, name: 'New instructions' },
+            { pattern: /system\s+prompt:/gi, name: 'System prompt' },
+            { pattern: /\[system\]/gi, name: 'System tag' },
+            { pattern: /important:\s*(override|ignore|disregard)/gi, name: 'Override directive' },
+            { pattern: /do\s+not\s+follow\s+(the\s+)?(previous|prior|above)/gi, name: 'Do not follow' },
+            { pattern: /override\s+(previous|prior|all)\s+(instructions?|prompts?)/gi, name: 'Override instructions' },
+            { pattern: /reset\s+(your\s+)?(instructions?|context|memory)/gi, name: 'Reset instructions' },
+            { pattern: /from\s+now\s+on,?\s+(you\s+)?(will|must|should)/gi, name: 'From now on directive' },
+            { pattern: /stop\s+being\s+(a|an)\s+/gi, name: 'Stop being' },
+            { pattern: /jailbreak/gi, name: 'Jailbreak keyword' },
+            { pattern: /\bDAN\b.*?(mode|prompt|jailbreak)/gi, name: 'DAN reference' },
+            { pattern: /developer\s+mode\s+(enabled|on|activated)/gi, name: 'Developer mode' },
+            { pattern: /bypass\s+(content\s+)?(filter|policy|restriction)/gi, name: 'Bypass filter' },
+            { pattern: /\u200b|\u200c|\u200d|\u2060|\ufeff/g, name: 'Hidden Unicode characters' },
+        ];
+
+        const uploadArea = document.getElementById('uploadArea');
+        const fileInput = document.getElementById('fileInput');
+        const loading = document.getElementById('loading');
+        const results = document.getElementById('results');
+        const status = document.getElementById('status');
+        const detectionList = document.getElementById('detectionList');
+
+        uploadArea.addEventListener('click', () => fileInput.click());
+
+        uploadArea.addEventListener('dragover', (e) => {
+            e.preventDefault();
+            uploadArea.classList.add('dragover');
+        });
+
+        uploadArea.addEventListener('dragleave', () => {
+            uploadArea.classList.remove('dragover');
+        });
+
+        uploadArea.addEventListener('drop', (e) => {
+            e.preventDefault();
+            uploadArea.classList.remove('dragover');
+            const file = e.dataTransfer.files[0];
+            if (file && file.type === 'application/pdf') {
+                processFile(file);
+            }
+        });
+
+        fileInput.addEventListener('change', (e) => {
+            const file = e.target.files[0];
+            if (file) {
+                processFile(file);
+            }
+        });
+
+        async function processFile(file) {
+            loading.classList.add('visible');
+            results.classList.remove('visible');
+
+            try {
+                const arrayBuffer = await file.arrayBuffer();
+                const pdf = await pdfjsLib.getDocument({ data: arrayBuffer }).promise;
+                const detections = [];
+
+                for (let pageNum = 1; pageNum <= pdf.numPages; pageNum++) {
+                    const page = await pdf.getPage(pageNum);
+                    const textContent = await page.getTextContent();
+                    const pageText = textContent.items.map(item => item.str).join(' ');
+
+                    for (const { pattern, name } of injectionPatterns) {
+                        pattern.lastIndex = 0;
+                        let match;
+                        while ((match = pattern.exec(pageText)) !== null) {
+                            const start = Math.max(0, match.index - 50);
+                            const end = Math.min(pageText.length, match.index + match[0].length + 50);
+                            const context = pageText.slice(start, end);
+
+                            detections.push({
+                                page: pageNum,
+                                type: name,
+                                match: match[0],
+                                context: (start > 0 ? '...' : '') + context + (end < pageText.length ? '...' : '')
+                            });
+                        }
+                    }
+                }
+
+                displayResults(detections);
+            } catch (error) {
+                status.className = 'status warning';
+                status.innerHTML = '<strong>Error:</strong> Could not process the PDF. Please ensure it is a valid PDF file.';
+                results.classList.add('visible');
+            } finally {
+                loading.classList.remove('visible');
+            }
+        }
+
+        function displayResults(detections) {
+            detectionList.innerHTML = '';
+
+            if (detections.length === 0) {
+                status.className = 'status clean';
+                status.innerHTML = '<strong>No issues detected.</strong> This PDF appears to be free of common prompt injection patterns.';
+            } else {
+                status.className = 'status warning';
+                status.innerHTML = `<strong>Warning:</strong> Found ${detections.length} potential prompt injection${detections.length > 1 ? 's' : ''}.`;
+
+                for (const detection of detections) {
+                    const item = document.createElement('div');
+                    item.className = 'detection-item';
+                    item.innerHTML = `
+                        <p class="page">Page ${detection.page} &mdash; ${detection.type}</p>
+                        <p>Matched: <code>${escapeHtml(detection.match)}</code></p>
+                        <div class="text">${escapeHtml(detection.context)}</div>
+                    `;
+                    detectionList.appendChild(item);
+                }
+            }
+
+            results.classList.add('visible');
+        }
+
+        function escapeHtml(text) {
+            const div = document.createElement('div');
+            div.textContent = text;
+            return div.innerHTML;
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `/tools` directory for hosting simple, useful web tools
- First tool: PDF Prompt Injection Detector - scans PDFs for common injection patterns
- All processing client-side (privacy-friendly, no server uploads)

## Changes
- `tools/index.html` - Tools landing page
- `tools/css/tools.css` - Shared styles mirroring main site
- `tools/pdf-prompt-detector/index.html` - The detector tool using PDF.js

## Test plan
- [ ] Visit `/tools` and verify landing page displays correctly
- [ ] Visit `/tools/pdf-prompt-detector/` and test PDF upload
- [ ] Upload a clean PDF - should show "No issues detected"
- [ ] Upload a PDF with injection text - should show warnings with context