### PR TITLE
feat: add HUJSON formatter tool

### DIFF
--- a/tools/css/tools.css
+++ b/tools/css/tools.css
@@ -210,6 +210,116 @@ p {
   display: block;
 }
 
+/* Input section */
+.input-section {
+  margin: var(--spacing-double) 0;
+}
+
+.input-section label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 10px;
+}
+
+.input-section textarea {
+  width: 100%;
+  min-height: 200px;
+  padding: var(--spacing-base);
+  font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
+  font-size: 14px;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  resize: vertical;
+  box-sizing: border-box;
+  line-height: 1.5;
+}
+
+.input-section textarea:focus {
+  border-color: var(--primary-color);
+  outline: none;
+}
+
+/* Buttons */
+.primary-btn {
+  background-color: var(--primary-color);
+  color: white;
+  border: none;
+  padding: 10px 20px;
+  font-size: 1em;
+  font-family: var(--font-family);
+  cursor: pointer;
+  margin-top: var(--spacing-base);
+  margin-right: 10px;
+}
+
+.primary-btn:hover {
+  background-color: var(--link-hover);
+}
+
+.secondary-btn {
+  background-color: transparent;
+  color: var(--primary-color);
+  border: 1px solid var(--primary-color);
+  padding: 10px 20px;
+  font-size: 1em;
+  font-family: var(--font-family);
+  cursor: pointer;
+  margin-top: var(--spacing-base);
+}
+
+.secondary-btn:hover {
+  background-color: #f0f0f0;
+}
+
+.copy-btn {
+  background-color: transparent;
+  color: var(--primary-color);
+  border: 1px solid var(--primary-color);
+  padding: 5px 15px;
+  font-size: 0.9em;
+  font-family: var(--font-family);
+  cursor: pointer;
+}
+
+.copy-btn:hover {
+  background-color: #f0f0f0;
+}
+
+/* Output header */
+.output-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--spacing-base);
+}
+
+.output-header h2 {
+  margin: 0;
+  font-size: 1.2em;
+}
+
+/* Code output */
+.code-output {
+  background-color: #f8f8f8;
+  border: 1px solid var(--border-color);
+  padding: var(--spacing-base);
+  overflow-x: auto;
+  font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
+  font-size: 14px;
+  line-height: 1.5;
+  white-space: pre;
+  margin: 0;
+}
+
+/* Syntax highlighting */
+.syntax-key { color: #0451a5; }
+.syntax-string { color: #a31515; }
+.syntax-number { color: #098658; }
+.syntax-boolean { color: #0000ff; }
+.syntax-null { color: #0000ff; }
+.syntax-comment { color: #008000; font-style: italic; }
+.syntax-punctuation { color: #000000; }
+
 /* Responsive */
 @media only screen and (max-width: 480px) {
   .container {
@@ -218,5 +328,18 @@ p {
 
   .upload-area {
     padding: var(--spacing-base);
+  }
+
+  .output-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .output-header h2 {
+    margin-bottom: 10px;
+  }
+
+  .input-section textarea {
+    min-height: 150px;
   }
 }

--- a/tools/hujson-formatter/index.html
+++ b/tools/hujson-formatter/index.html
@@ -1,0 +1,241 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>HUJSON Formatter | Tools | Neil Rooney</title>
+    <meta name="description" content="Format and prettify HUJSON (JSON with comments and trailing commas) with syntax highlighting.">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../css/tools.css">
+</head>
+<body>
+    <main class="container">
+        <a href="../" class="back-link">&larr; Back to Tools</a>
+
+        <h1>HUJSON Formatter</h1>
+
+        <p>Paste HUJSON (JSON with comments and trailing commas) to format and prettify it. Comments are preserved in the output.</p>
+
+        <div class="input-section">
+            <label for="hujsonInput">Input HUJSON:</label>
+            <textarea id="hujsonInput" placeholder="Paste your HUJSON here..."></textarea>
+            <button id="formatBtn" class="primary-btn">Format</button>
+            <button id="clearBtn" class="secondary-btn">Clear</button>
+        </div>
+
+        <div class="loading" id="loading">
+            <p>Formatting...</p>
+        </div>
+
+        <div class="results" id="results">
+            <div class="status" id="status"></div>
+            <div class="output-header">
+                <h2>Formatted Output</h2>
+                <button id="copyBtn" class="copy-btn">Copy to Clipboard</button>
+            </div>
+            <pre class="code-output"><code id="formattedCode"></code></pre>
+        </div>
+    </main>
+
+    <script type="module">
+        import * as jsonc from 'https://cdn.jsdelivr.net/npm/jsonc-parser@3.3.1/+esm';
+
+        const input = document.getElementById('hujsonInput');
+        const formatBtn = document.getElementById('formatBtn');
+        const clearBtn = document.getElementById('clearBtn');
+        const copyBtn = document.getElementById('copyBtn');
+        const loading = document.getElementById('loading');
+        const results = document.getElementById('results');
+        const status = document.getElementById('status');
+        const formattedCode = document.getElementById('formattedCode');
+
+        let formattedText = '';
+
+        formatBtn.addEventListener('click', formatHujson);
+        clearBtn.addEventListener('click', clearAll);
+        copyBtn.addEventListener('click', copyToClipboard);
+
+        function formatHujson() {
+            const text = input.value.trim();
+            if (!text) {
+                showError('Please enter some HUJSON to format.');
+                return;
+            }
+
+            loading.classList.add('visible');
+            results.classList.remove('visible');
+
+            setTimeout(() => {
+                try {
+                    const parseErrors = [];
+                    jsonc.parse(text, parseErrors, {
+                        allowTrailingComma: true,
+                        allowEmptyContent: true
+                    });
+
+                    if (parseErrors.length > 0) {
+                        const err = parseErrors[0];
+                        showError(`Parse error at offset ${err.offset}: ${getParseErrorMessage(err.error)}`);
+                        loading.classList.remove('visible');
+                        return;
+                    }
+
+                    const edits = jsonc.format(text, undefined, {
+                        tabSize: 2,
+                        insertSpaces: true,
+                        eol: '\n'
+                    });
+                    formattedText = jsonc.applyEdits(text, edits);
+
+                    const highlighted = syntaxHighlight(formattedText);
+                    formattedCode.innerHTML = highlighted;
+
+                    showSuccess('Formatted successfully!');
+                } catch (err) {
+                    showError(`Error: ${err.message}`);
+                } finally {
+                    loading.classList.remove('visible');
+                }
+            }, 10);
+        }
+
+        function syntaxHighlight(text) {
+            const tokens = [];
+            const scanner = jsonc.createScanner(text, false);
+
+            while (scanner.scan() !== 17) { // 17 = EOF
+                tokens.push({
+                    kind: scanner.getToken(),
+                    offset: scanner.getTokenOffset(),
+                    length: scanner.getTokenLength(),
+                    value: text.substring(scanner.getTokenOffset(), scanner.getTokenOffset() + scanner.getTokenLength())
+                });
+            }
+
+            // Mark keys (string followed by colon)
+            for (let i = 0; i < tokens.length - 1; i++) {
+                if (tokens[i].kind === 10 && tokens[i + 1].kind === 6) { // 10 = StringLiteral, 6 = ColonToken
+                    tokens[i].isKey = true;
+                }
+            }
+
+            let result = '';
+            let lastEnd = 0;
+
+            for (const token of tokens) {
+                // Add whitespace between tokens
+                if (token.offset > lastEnd) {
+                    result += escapeHtml(text.substring(lastEnd, token.offset));
+                }
+
+                const className = getTokenClass(token);
+                if (className) {
+                    result += `<span class="${className}">${escapeHtml(token.value)}</span>`;
+                } else {
+                    result += escapeHtml(token.value);
+                }
+
+                lastEnd = token.offset + token.length;
+            }
+
+            // Add remaining content
+            if (lastEnd < text.length) {
+                result += escapeHtml(text.substring(lastEnd));
+            }
+
+            return result;
+        }
+
+        function getTokenClass(token) {
+            // SyntaxKind values from jsonc-parser
+            switch (token.kind) {
+                case 10: // StringLiteral
+                    return token.isKey ? 'syntax-key' : 'syntax-string';
+                case 11: // NumericLiteral
+                    return 'syntax-number';
+                case 8: // TrueKeyword
+                case 9: // FalseKeyword
+                    return 'syntax-boolean';
+                case 7: // NullKeyword
+                    return 'syntax-null';
+                case 12: // LineCommentTrivia
+                case 13: // BlockCommentTrivia
+                    return 'syntax-comment';
+                case 1: // OpenBraceToken
+                case 2: // CloseBraceToken
+                case 3: // OpenBracketToken
+                case 4: // CloseBracketToken
+                case 5: // CommaToken
+                case 6: // ColonToken
+                    return 'syntax-punctuation';
+                default:
+                    return null;
+            }
+        }
+
+        function getParseErrorMessage(errorCode) {
+            const messages = {
+                1: 'Invalid symbol',
+                2: 'Invalid number format',
+                3: 'Property name expected',
+                4: 'Value expected',
+                5: 'Colon expected',
+                6: 'Comma expected',
+                7: 'Closing brace expected',
+                8: 'Closing bracket expected',
+                9: 'End of file expected',
+                10: 'Invalid comment token',
+                11: 'Unexpected end of comment',
+                12: 'Unexpected end of string',
+                13: 'Unexpected end of number',
+                14: 'Invalid Unicode',
+                15: 'Invalid escape character',
+                16: 'Invalid character'
+            };
+            return messages[errorCode] || 'Unknown error';
+        }
+
+        function showSuccess(message) {
+            status.className = 'status clean';
+            status.innerHTML = `<strong>${message}</strong>`;
+            results.classList.add('visible');
+        }
+
+        function showError(message) {
+            status.className = 'status warning';
+            status.innerHTML = `<strong>Error:</strong> ${escapeHtml(message)}`;
+            results.classList.add('visible');
+            formattedCode.innerHTML = '';
+        }
+
+        function clearAll() {
+            input.value = '';
+            results.classList.remove('visible');
+            formattedText = '';
+        }
+
+        async function copyToClipboard() {
+            try {
+                await navigator.clipboard.writeText(formattedText);
+                copyBtn.textContent = 'Copied!';
+                setTimeout(() => {
+                    copyBtn.textContent = 'Copy to Clipboard';
+                }, 2000);
+            } catch (err) {
+                copyBtn.textContent = 'Failed to copy';
+                setTimeout(() => {
+                    copyBtn.textContent = 'Copy to Clipboard';
+                }, 2000);
+            }
+        }
+
+        function escapeHtml(text) {
+            const div = document.createElement('div');
+            div.textContent = text;
+            return div.innerHTML;
+        }
+    </script>
+</body>
+</html>

--- a/tools/index.html
+++ b/tools/index.html
@@ -20,6 +20,10 @@
 
         <ul class="tool-list">
             <li>
+                <a href="hujson-formatter/">HUJSON Formatter</a>
+                <p class="tool-description">Format and prettify HUJSON (JSON with comments and trailing commas) with syntax highlighting.</p>
+            </li>
+            <li>
                 <a href="pdf-prompt-detector/">PDF Prompt Injection Detector</a>
                 <p class="tool-description">Upload a PDF to check for potential prompt injection attempts. Useful for screening studies and documents before processing with AI.</p>
             </li>


### PR DESCRIPTION
## Summary
- Add new HUJSON formatter tool to the tools directory
- Formats and prettifies JSON with comments and trailing commas
- Includes syntax highlighting for all token types

## Changes
- Created `/tools/hujson-formatter/index.html` with formatter logic using jsonc-parser
- Added input, button, and syntax highlighting styles to `/tools/css/tools.css`
- Updated `/tools/index.html` to list the new tool

## Features
- Text area input for pasting HUJSON
- Prettifies with proper indentation (2 spaces)
- Syntax highlighting: keys (blue), strings (maroon), numbers (green), booleans/null (blue), comments (green italic)
- Preserves comments and trailing commas in output
- Copy to clipboard button
- Error messages for malformed input
- Responsive design for mobile

## Test plan
- [ ] Open `/tools/hujson-formatter/` in browser
- [ ] Paste HUJSON with comments and trailing commas
- [ ] Click Format and verify output is prettified with syntax highlighting
- [ ] Test Copy to Clipboard functionality
- [ ] Test with malformed JSON to verify error handling