### PR TITLE
style: standardise styling across all pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
   <link rel="canonical" href="https://neilrooney.com/" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700,400italic,300,300italic&display=swap" rel="stylesheet" type="text/css">
+  <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/main.css" type="text/css">
   <link rel="preload" href="css/main.css" as="style">
   <script type="application/ld+json">

--- a/tools/css/tools.css
+++ b/tools/css/tools.css
@@ -1,5 +1,5 @@
 
-html, body, h1, h2, p, a, img, ul, li, main, section, nav, div, button, input, label {
+html, body, h1, h2, p, a, img, ul, li, main, section, nav, div, button, input, textarea, label {
     margin: 0;
     padding: 0;
     border: 0;
@@ -59,6 +59,7 @@ blockquote, q {
   --warning-color: #d9534f;
   --success-color: #5cb85c;
   --border-color: #ddd;
+  --text-muted: #666;
 }
 
 
@@ -113,7 +114,7 @@ p {
 }
 
 .tool-description {
-  color: #666;
+  color: var(--text-muted);
   font-size: 0.9em;
 }
 
@@ -142,7 +143,7 @@ p {
 }
 
 .upload-area .hint {
-  color: #666;
+  color: var(--text-muted);
   font-size: 0.9em;
   margin-top: var(--spacing-base);
 }


### PR DESCRIPTION
## Summary
Standardise styling consistency between the main site and tools pages.

## Changes
- Update Google Fonts URL to css2 API format in `index.html` (matches tools pages)
- Add `textarea` to CSS reset in `tools/css/tools.css`
- Add `--text-muted` CSS variable for muted text colours
- Replace hardcoded `#666` with `var(--text-muted)` in `.tool-description` and `.upload-area .hint`

## Test plan
- [ ] Verify main page loads with correct fonts
- [ ] Verify tools pages load with correct styling
- [ ] Check muted text appears correctly on tools index