### PR TITLE
fix(favicon): allow Googlebot-Image to crawl favicon

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -6,4 +6,8 @@ Allow: /
 Disallow: /css/
 Disallow: /images/
 
+User-agent: Googlebot-Image
+Allow: /favicon.png
+Disallow: /
+
 Sitemap: https://neilrooney.com/sitemap.xml


### PR DESCRIPTION
## Summary
- Allow Googlebot-Image to access `/favicon.png` so Google can display the site favicon in search results

## Changes
- Added `Googlebot-Image` user-agent rules to `robots.txt`
- Explicitly allows `/favicon.png` while blocking other paths

## Context
The wildcard `User-agent: *` rule with `Disallow: /` was blocking Googlebot-Image from accessing the favicon. Google requires both Googlebot and Googlebot-Image to crawl the favicon for it to appear in search results.

## Test plan
- [ ] Verify robots.txt is accessible at https://neilrooney.com/robots.txt after deploy
- [ ] Use [Google's Rich Results Test](https://search.google.com/test/rich-results) or Search Console to verify crawlability
- [ ] Monitor search results for favicon appearance (may take days to weeks)