### PR TITLE
feat(seo): add Twitter Card meta tags and charset declaration

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE HTML>
 <html lang="en">
 <head>
+  <meta charset="UTF-8">
   <title>Neil Rooney | Director of IT</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Neil Rooney is a Director of IT based in Berlin, Germany. Specialising in corporate IT, cyber security, and management.">
@@ -11,6 +12,10 @@
   <meta property="og:image" content="https://neilrooney.com/images/neil-400.webp">
   <meta property="og:url" content="https://neilrooney.com">
   <meta name="theme-color" content="#000000">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="Neil Rooney | Director of IT">
+  <meta name="twitter:description" content="Neil Rooney is a Director of IT based in Berlin, Germany. Specialising in corporate IT, cyber security, and management.">
+  <meta name="twitter:image" content="https://neilrooney.com/images/neil-400.webp">
   <link rel="icon" type="image/png" href="/favicon.png">
   <link rel="canonical" href="https://neilrooney.com/" />
   <link rel="stylesheet" href="css/main.css" type="text/css">


### PR DESCRIPTION
## Summary
- Add `<meta charset="UTF-8">` as first element in `<head>` for explicit character encoding
- Add Twitter Card meta tags for rich social previews when shared on X/Twitter

## Changes
- `twitter:card` - summary card type
- `twitter:title` - matches Open Graph title
- `twitter:description` - matches Open Graph description
- `twitter:image` - matches Open Graph image

## Test plan
- [ ] Verify page renders correctly locally
- [ ] After deploy, test Twitter Card preview at https://cards-dev.twitter.com/validator
- [ ] Validate HTML at https://validator.w3.org/