### PR TITLE
fix(seo): add 404 page and remove image noindex header

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,25 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Page Not Found | Neil Rooney</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex">
+  <link rel="icon" type="image/png" href="/favicon.png">
+  <link rel="stylesheet" href="/css/main.css" type="text/css">
+</head>
+<body>
+  <main id="content">
+    <section id="description">
+      <h1>404</h1>
+      <p class="title">Page not found</p>
+      <p class="intro">The page you're looking for doesn't exist.<span class="cursor"></span></p>
+      <nav>
+        <ul>
+          <li><a href="/">Home</a></li>
+        </ul>
+      </nav>
+    </section>
+  </main>
+</body>
+</html>

--- a/_headers
+++ b/_headers
@@ -11,7 +11,6 @@
 
 /images/*
   Cache-Control: public, max-age=31536000, immutable
-  X-Robots-Tag: noindex
 
 /fonts/*
   Cache-Control: public, max-age=31536000, immutable


### PR DESCRIPTION
## Changes
- Add custom `404.html` matching the site design so Cloudflare Pages returns HTTP 404 for non-existent routes instead of soft 404s (HTTP 200 serving `index.html`)
- Remove `X-Robots-Tag: noindex` from `/images/*` in `_headers` to resolve conflict with `robots.txt` allowing Googlebot-Image to crawl and index images

## Testing
- Deploy to preview and visit a non-existent route (e.g. `/test-404`) — should show the 404 page with correct status code
- Verify image headers no longer include `X-Robots-Tag: noindex`