### PR TITLE
perf(fonts): preload critical fonts and add Early Hints headers

### DIFF
--- a/404.html
+++ b/404.html
@@ -6,6 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="robots" content="noindex">
   <link rel="icon" type="image/png" href="/favicon.png">
+  <link rel="preload" href="/fonts/Inter-Regular.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/fonts/Inter-SemiBold.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/css/main.css" type="text/css">
 </head>
 <body>

--- a/_headers
+++ b/_headers
@@ -4,6 +4,9 @@
   X-Content-Type-Options: nosniff
   X-XSS-Protection: 1; mode=block
   Cache-Control: public, max-age=2592000
+  Link: </css/main.css>; rel=preload; as=style
+  Link: </fonts/Inter-Regular.woff2>; rel=preload; as=font; type=font/woff2; crossorigin
+  Link: </fonts/Inter-SemiBold.woff2>; rel=preload; as=font; type=font/woff2; crossorigin
 
 /css/*
   Cache-Control: public, max-age=31536000, immutable

--- a/index.html
+++ b/index.html
@@ -18,6 +18,8 @@
   <meta name="twitter:image" content="https://neilrooney.com/images/neil-400.webp">
   <link rel="icon" type="image/png" href="/favicon.png">
   <link rel="canonical" href="https://neilrooney.com/" />
+  <link rel="preload" href="/fonts/Inter-Regular.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/fonts/Inter-SemiBold.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="css/main.css" type="text/css">
   <script type="application/ld+json">
   {


### PR DESCRIPTION
Preload critical fonts and add Cloudflare Early Hints headers to flatten the critical request chain and improve FCP.

## Changes
- Add `<link rel="preload">` for Inter-Regular and Inter-SemiBold fonts in `index.html` and `404.html`
- Add `Link` preload headers for CSS and both fonts in `_headers` to enable Cloudflare 103 Early Hints

## Testing
1. Serve locally and confirm both pages render identically with no duplicate font downloads in DevTools Network tab
2. Deploy to Cloudflare Pages preview branch
3. Verify `Link` headers are present: `curl -sI https://<preview-url>/`
4. Run PageSpeed Insights — confirm no regressions and fonts load in parallel in the critical chain
5. Visit the preview URL twice and verify Early Hints are active on the second visit

## Related
Addresses PageSpeed Insights diagnostics for render-blocking CSS and critical request chain depth