### PR TITLE
feat(resume): add resume page with work history and education

### DIFF
--- a/_headers
+++ b/_headers
@@ -8,6 +8,9 @@
   Link: </fonts/Inter-Regular.woff2>; rel=preload; as=font; type=font/woff2; crossorigin
   Link: </fonts/Inter-SemiBold.woff2>; rel=preload; as=font; type=font/woff2; crossorigin
 
+/resume
+  X-Robots-Tag: noindex
+
 /css/*
   Cache-Control: public, max-age=31536000, immutable
   X-Robots-Tag: noindex

--- a/css/main.css
+++ b/css/main.css
@@ -209,6 +209,11 @@ nav a {
   padding-top: 2px;
 }
 
+.role-duration {
+  color: #999;
+  font-size: 0.8125rem;
+}
+
 .role-org {
   color: #999;
   font-size: 0.875rem;

--- a/css/main.css
+++ b/css/main.css
@@ -156,6 +156,64 @@ nav a {
   padding: var(--spacing-xs) 0;
 }
 
+/* Resume */
+#content.resume {
+  justify-content: flex-start;
+}
+
+.resume h2 {
+  color: var(--text-secondary);
+  font-weight: 400;
+  margin-bottom: calc(-1 * var(--spacing-xs));
+}
+
+.resume-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+  width: 100%;
+}
+
+.resume-section + .resume-section {
+  border-top: 1px solid var(--border);
+  padding-top: var(--spacing-md);
+}
+
+.company {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  position: relative;
+}
+
+.company.promoted::before {
+  content: '';
+  position: absolute;
+  left: calc(-1 * var(--spacing-sm));
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--border);
+}
+
+.role {
+  display: grid;
+  grid-template-columns: 10rem 1fr;
+  gap: 0 var(--spacing-sm);
+}
+
+.role-date {
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+  white-space: nowrap;
+  padding-top: 2px;
+}
+
+.role-org {
+  color: #999;
+  font-size: 0.875rem;
+}
+
 /* Mobile */
 @media (max-width: 640px) {
   #content {
@@ -170,5 +228,17 @@ nav a {
 
   nav ul {
     justify-content: center;
+  }
+
+  .role {
+    grid-template-columns: 1fr;
+  }
+
+  .role-date {
+    padding-top: 0;
+  }
+
+  .company.promoted::before {
+    display: none;
   }
 }

--- a/css/main.css
+++ b/css/main.css
@@ -184,16 +184,22 @@ nav a {
   flex-direction: column;
   gap: var(--spacing-sm);
   position: relative;
+  padding-left: var(--spacing-sm);
 }
 
 .company.promoted::before {
   content: '';
   position: absolute;
-  left: calc(-1 * var(--spacing-sm));
+  left: 0;
   top: 0;
   bottom: 0;
   width: 2px;
   background: var(--border);
+}
+
+.role-period {
+  display: flex;
+  flex-direction: column;
 }
 
 .role {
@@ -241,6 +247,10 @@ nav a {
 
   .role-date {
     padding-top: 0;
+  }
+
+  .company {
+    padding-left: 0;
   }
 
   .company.promoted::before {

--- a/index.html
+++ b/index.html
@@ -61,6 +61,7 @@
       </p>
       <nav>
         <ul>
+          <li><a href="/resume">Resume</a></li>
           <li><a href="https://bsky.app/profile/neilrooney.com" rel="noopener me">Bluesky</a></li>
           <li><a href="https://github.com/neilrooney" rel="noopener me">GitHub</a></li>
           <li><a href="https://www.linkedin.com/in/neil-rooney/" rel="noopener me">LinkedIn</a></li>

--- a/index.html
+++ b/index.html
@@ -61,10 +61,10 @@
       </p>
       <nav>
         <ul>
-          <li><a href="/resume">Resume</a></li>
           <li><a href="https://bsky.app/profile/neilrooney.com" rel="noopener me">Bluesky</a></li>
           <li><a href="https://github.com/neilrooney" rel="noopener me">GitHub</a></li>
           <li><a href="https://www.linkedin.com/in/neil-rooney/" rel="noopener me">LinkedIn</a></li>
+          <li><a href="/resume">Resume</a></li>
         </ul>
       </nav>
     </section>

--- a/resume.html
+++ b/resume.html
@@ -14,12 +14,24 @@
   <main id="content" class="resume">
     <h1>Resume</h1>
 
+    <nav>
+      <ul>
+        <li><a href="/">Home</a></li>
+        <li><a href="https://bsky.app/profile/neilrooney.com" rel="noopener me">Bluesky</a></li>
+        <li><a href="https://github.com/neilrooney" rel="noopener me">GitHub</a></li>
+        <li><a href="https://www.linkedin.com/in/neil-rooney/" rel="noopener me">LinkedIn</a></li>
+      </ul>
+    </nav>
+
     <section class="resume-section">
       <h2 class="mono">Experience</h2>
 
       <div class="company promoted">
         <div class="role">
-          <time class="role-date">Mar 2025 – Present</time>
+          <div class="role-period">
+            <time class="role-date">Mar 2025 – Present</time>
+            <span class="role-duration">3+ years</span>
+          </div>
           <div class="role-info">
             <p class="role-title">Director of IT</p>
             <p class="role-org">Taxfix</p>
@@ -36,7 +48,10 @@
 
       <div class="company promoted">
         <div class="role">
-          <time class="role-date">May 2022 – May 2023</time>
+          <div class="role-period">
+            <time class="role-date">May 2022 – May 2023</time>
+            <span class="role-duration">4 years</span>
+          </div>
           <div class="role-info">
             <p class="role-title">Head of SysOps Engineering</p>
             <p class="role-org">Ada Health</p>
@@ -60,7 +75,10 @@
 
       <div class="company">
         <div class="role">
-          <time class="role-date">Oct 2017 – Apr 2019</time>
+          <div class="role-period">
+            <time class="role-date">Oct 2017 – Apr 2019</time>
+            <span class="role-duration">1.5 years</span>
+          </div>
           <div class="role-info">
             <p class="role-title">Senior System Administrator</p>
             <p class="role-org">Uberall</p>
@@ -70,7 +88,10 @@
 
       <div class="company promoted">
         <div class="role">
-          <time class="role-date">Dec 2016 – Sep 2017</time>
+          <div class="role-period">
+            <time class="role-date">Dec 2016 – Sep 2017</time>
+            <span class="role-duration">2 years</span>
+          </div>
           <div class="role-info">
             <p class="role-title">Head of Internal IT</p>
             <p class="role-org">Amadeus</p>
@@ -91,7 +112,10 @@
 
       <div class="company">
         <div class="role">
-          <time class="role-date">2007 – 2010</time>
+          <div class="role-period">
+            <time class="role-date">2006 – 2010</time>
+            <span class="role-duration">4 years</span>
+          </div>
           <div class="role-info">
             <p class="role-title">BSc Forensic Science and Criminal Investigation</p>
             <p class="role-org">University of Central Lancashire</p>
@@ -99,12 +123,6 @@
         </div>
       </div>
     </section>
-
-    <nav>
-      <ul>
-        <li><a href="/">Home</a></li>
-      </ul>
-    </nav>
   </main>
 </body>
 </html>

--- a/resume.html
+++ b/resume.html
@@ -1,0 +1,110 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Resume | Neil Rooney</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex">
+  <link rel="icon" type="image/png" href="/favicon.png">
+  <link rel="preload" href="/fonts/Inter-Regular.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/fonts/Inter-SemiBold.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="stylesheet" href="/css/main.css" type="text/css">
+</head>
+<body>
+  <main id="content" class="resume">
+    <h1>Resume</h1>
+
+    <section class="resume-section">
+      <h2 class="mono">Experience</h2>
+
+      <div class="company promoted">
+        <div class="role">
+          <time class="role-date">Mar 2025 – Present</time>
+          <div class="role-info">
+            <p class="role-title">Director of IT</p>
+            <p class="role-org">Taxfix</p>
+          </div>
+        </div>
+        <div class="role">
+          <time class="role-date">May 2023 – Mar 2025</time>
+          <div class="role-info">
+            <p class="role-title">Head of IT</p>
+            <p class="role-org">Taxfix</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="company promoted">
+        <div class="role">
+          <time class="role-date">May 2022 – May 2023</time>
+          <div class="role-info">
+            <p class="role-title">Head of SysOps Engineering</p>
+            <p class="role-org">Ada Health</p>
+          </div>
+        </div>
+        <div class="role">
+          <time class="role-date">Jun 2020 – May 2022</time>
+          <div class="role-info">
+            <p class="role-title">Head of System Administration</p>
+            <p class="role-org">Ada Health</p>
+          </div>
+        </div>
+        <div class="role">
+          <time class="role-date">Jun 2019 – May 2020</time>
+          <div class="role-info">
+            <p class="role-title">Senior IT System Administrator</p>
+            <p class="role-org">Ada Health</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="company">
+        <div class="role">
+          <time class="role-date">Oct 2017 – Apr 2019</time>
+          <div class="role-info">
+            <p class="role-title">Senior System Administrator</p>
+            <p class="role-org">Uberall</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="company promoted">
+        <div class="role">
+          <time class="role-date">Dec 2016 – Sep 2017</time>
+          <div class="role-info">
+            <p class="role-title">Head of Internal IT</p>
+            <p class="role-org">Amadeus</p>
+          </div>
+        </div>
+        <div class="role">
+          <time class="role-date">Sep 2015 – Nov 2016</time>
+          <div class="role-info">
+            <p class="role-title">System Administrator</p>
+            <p class="role-org">Amadeus</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="resume-section">
+      <h2 class="mono">Education</h2>
+
+      <div class="company">
+        <div class="role">
+          <time class="role-date">2007 – 2010</time>
+          <div class="role-info">
+            <p class="role-title">BSc Forensic Science and Criminal Investigation</p>
+            <p class="role-org">University of Central Lancashire</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <nav>
+      <ul>
+        <li><a href="/">Home</a></li>
+      </ul>
+    </nav>
+  </main>
+</body>
+</html>

--- a/resume.html
+++ b/resume.html
@@ -112,10 +112,7 @@
 
       <div class="company">
         <div class="role">
-          <div class="role-period">
-            <time class="role-date">2006 – 2010</time>
-            <span class="role-duration">4 years</span>
-          </div>
+          <time class="role-date">2006 – 2010</time>
           <div class="role-info">
             <p class="role-title">BSc Forensic Science and Criminal Investigation</p>
             <p class="role-org">University of Central Lancashire</p>


### PR DESCRIPTION
Add a new /resume page displaying work history and education, matching the existing site design.

## Changes
- Create `resume.html` with career history (Taxfix, Ada Health, Uberall, Amadeus) and education (UCLan BSc)
- Add resume-specific CSS: two-column grid layout (date | title + company), subtle promotion indicator line for multi-role tenures
- Add `X-Robots-Tag: noindex` header for `/resume` in `_headers`
- Add "Resume" nav link to homepage

## Testing
- Serve locally with `npx serve .` and visit `/resume`
- Verify layout matches site design (fonts, spacing, colours)
- Check responsive behaviour at <=640px (stacked layout, centred text)
- Confirm promotion line appears for Taxfix, Ada Health, Amadeus groups
- Verify `noindex` via meta tag and response header