### PR TITLE
chore: remove bluesky profile link

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# AGENTS.md
+
+## Repo Shape
+- This is a hand-written static site for `https://neilrooney.com`; there is no package manager, build step, lint, formatter, or automated test config in the repo.
+- Main entrypoints: `index.html` for the home page, `404.html` for the Cloudflare Pages custom 404, `css/main.css` for shared styles, `_headers` for Cloudflare Pages response headers/cache/preload rules, and `robots.txt`/`sitemap.xml` for indexing.
+- Asset paths assume the site is served from the repository root. Do not validate by opening `index.html` with `file://`; use a static server.
+
+## Commands
+- Preview locally from the repo root: `python3 -m http.server 8000`, then open `http://localhost:8000/`.
+- There is no install, test, build, lint, or typecheck command unless you add that tooling as part of the change.
+- For focused manual checks, visit `/`, `/404.html`, `/robots.txt`, and `/sitemap.xml` in the local server. Local previews do not apply Cloudflare Pages `_headers`.
+
+## Change Notes
+- Deployment is via Cloudflare Pages, but no GitHub Actions or release workflow is defined here; confirm the production branch and deploy trigger in Cloudflare Pages before release-sensitive changes.
+- `_headers` sets a restrictive CSP (`default-src 'none'`) and immutable caching for `/css/*`, `/images/*`, and `/fonts/*`. Update it when adding external scripts/styles/images/fonts or changing cache-sensitive asset paths.
+- When changing identity, profile image, title, description, or URL data, keep visible copy, canonical URL, Open Graph/Twitter tags, JSON-LD `Person`, `robots.txt`, and `sitemap.xml` aligned.
+- Keep public-facing copy in British English to match existing content (`Specialising`, `Acknowledgements`).

--- a/index.html
+++ b/index.html
@@ -37,8 +37,7 @@
     "image": "https://neilrooney.com/images/neil-400.webp",
     "sameAs": [
       "https://github.com/neilrooney",
-      "https://www.linkedin.com/in/neil-rooney/",
-      "https://bsky.app/profile/neilrooney.com"
+      "https://www.linkedin.com/in/neil-rooney/"
     ]
   }
   </script>
@@ -61,7 +60,6 @@
       </p>
       <nav>
         <ul>
-          <li><a href="https://bsky.app/profile/neilrooney.com" rel="noopener me">Bluesky</a></li>
           <li><a href="https://github.com/neilrooney" rel="noopener me">GitHub</a></li>
           <li><a href="https://www.linkedin.com/in/neil-rooney/" rel="noopener me">LinkedIn</a></li>
         </ul>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,6 +2,6 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://neilrooney.com/</loc>
-    <lastmod>2026-01-25</lastmod>
+    <lastmod>2026-05-24</lastmod>
   </url>
 </urlset>


### PR DESCRIPTION
Removes the Bluesky profile link from the site and updates repository agent guidance.

## Changes
- Add AGENTS.md with compact repo instructions for future OpenCode sessions
- Remove Bluesky from the visible home page navigation
- Remove Bluesky from JSON-LD sameAs metadata
- Update sitemap lastmod to 2026-05-24

## Testing
- Focused Python static check passed: JSON-LD parsed, sitemap XML parsed, no Bluesky reference remains, and sitemap lastmod is updated

## Related
- No ticket